### PR TITLE
chore: recon/정산 도구 changeset 추가 (minor)

### DIFF
--- a/.changeset/reconciliation-tools.md
+++ b/.changeset/reconciliation-tools.md
@@ -1,0 +1,5 @@
+---
+"@portone/mcp-server": minor
+---
+
+정산/거래대사 조회 도구 추가 (getReconciliationsByFilter, getSettlementSummaries, getSettlementStatistics). 특정 상점(store) 단위로 거래대사 건별 내역·불일치 사유, 정산 요약, 정산 통계를 조회하며 조회 기간은 최근 6개월 이내·최대 3개월로 제한됩니다.


### PR DESCRIPTION
## 개요

#57 에서 병합된 **정산/거래대사 조회 도구**에 대한 changeset 을 추가합니다. 해당 기능이 버전 범프 없이 병합되어, 다음 릴리스(0.17.0)에 포함되도록 minor changeset 을 작성합니다.

## 변경

- `.changeset/reconciliation-tools.md` — `@portone/mcp-server`: **minor**

내용:
> 정산/거래대사 조회 도구 추가 (getReconciliationsByFilter, getSettlementSummaries, getSettlementStatistics). 특정 상점(store) 단위로 거래대사 건별 내역·불일치 사유, 정산 요약, 정산 통계를 조회하며 조회 기간은 최근 6개월 이내·최대 3개월로 제한됩니다.

머지되면 changesets 의 "Version Packages" 워크플로가 0.16.0 → 0.17.0 범프 및 CHANGELOG 갱신 PR 을 생성합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)