### PR TITLE
chore: recon/정산 도구 changeset 추가 (minor, 0.17.0)

### DIFF
--- a/.changeset/reconciliation-tools.md
+++ b/.changeset/reconciliation-tools.md
@@ -1,0 +1,5 @@
+---
+"@portone/mcp-server": minor
+---
+
+정산/거래대사 조회 도구 추가 (getReconciliationsByFilter, getSettlementSummaries, getSettlementStatistics). 특정 상점(store) 단위로 거래대사 건별 내역·불일치 사유, 정산 요약, 정산 통계를 조회하며 조회 기간은 최근 6개월 이내·최대 3개월로 제한됩니다.


### PR DESCRIPTION
## 개요

#57 에서 병합된 **정산/거래대사 조회 도구**를 배포하기 위한 **minor** changeset 을 추가합니다. 해당 기능이 버전 범프 없이 병합되어 현재 어느 버전으로도 배포되지 않은 상태이므로, 0.16.0 → **0.17.0** 범프를 위한 changeset 입니다.

## 변경

- `.changeset/reconciliation-tools.md` — `@portone/mcp-server`: **minor**

내용:
> 정산/거래대사 조회 도구 추가 (getReconciliationsByFilter, getSettlementSummaries, getSettlementStatistics). 특정 상점(store) 단위로 거래대사 건별 내역·불일치 사유, 정산 요약, 정산 통계를 조회하며 조회 기간은 최근 6개월 이내·최대 3개월로 제한됩니다.

## 배포 흐름

1. 이 PR 머지 → CD(changesets)가 **"Version Packages" PR** 자동 생성 (0.16.0 → 0.17.0, CHANGELOG 갱신)
2. "Version Packages" PR 머지 → CD가 `changeset publish` 로 **npm 0.17.0 배포** + **GitHub Release v0.17.0**(DXT 포함) 자동 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)