### PR TITLE
feat: 거래대사/정산 조회 기간 제약 축소 (1개월 / 2주)

### DIFF
--- a/.changeset/recon-date-range.md
+++ b/.changeset/recon-date-range.md
@@ -1,0 +1,5 @@
+---
+"@portone/mcp-server": patch
+---
+
+거래대사/정산 조회 기간 제약 조정: 정산 요약·통계는 최대 1개월, 건별 거래대사 내역(getReconciliationsByFilter)은 최대 2주로 축소했습니다. (최근 6개월 이내 시작일 제약은 유지)

--- a/src/tools/getReconciliationsByFilter.ts
+++ b/src/tools/getReconciliationsByFilter.ts
@@ -136,7 +136,7 @@ export const config = {
 대사 불일치 상세는 statuses=[NOT_MATCHED] 로 조회 후 각 건의 notMatchedReasons 를 확인합니다.
 대사 불가 사유는 INCOMPARABLE 건의 incomparableReason 필드에서 확인합니다.
 날짜는 반드시 YYYY-MM-DD 형식으로 입력하며, dateType 으로 정산일/결제일 기준을 선택합니다.
-조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 3개월입니다.
+조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 2주입니다.
 store 아이디는 list_stores 도구로 먼저 조회할 수 있습니다.`,
   inputSchema: InputSchema.shape,
   outputSchema: OutputSchema.shape,
@@ -210,7 +210,9 @@ export function init(
     first,
     after,
   }) => {
-    const dateRangeError = validateReconciliationDateRange(from, to);
+    const dateRangeError = validateReconciliationDateRange(from, to, {
+      days: 14,
+    });
     if (dateRangeError != null) {
       return toolErrorResult({
         type: "error",

--- a/src/tools/getSettlementStatistics.ts
+++ b/src/tools/getSettlementStatistics.ts
@@ -49,7 +49,7 @@ export const config = {
 
 검색 구간 내 통화별 합산 통계(정산/정산예정 금액·건수)와 일별 통계를 제공합니다.
 날짜는 반드시 YYYY-MM-DD 형식으로 입력합니다.
-조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 3개월입니다.
+조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 1개월입니다.
 store 아이디는 list_stores 도구로 먼저 조회할 수 있습니다.`,
   inputSchema: InputSchema.shape,
   outputSchema: OutputSchema.shape,
@@ -60,7 +60,9 @@ export function init(
   client: GraphQLClient,
 ): ToolCallback<typeof config.inputSchema> {
   return async ({ store, from, to }) => {
-    const dateRangeError = validateReconciliationDateRange(from, to);
+    const dateRangeError = validateReconciliationDateRange(from, to, {
+      months: 1,
+    });
     if (dateRangeError != null) {
       return toolErrorResult({
         type: "error",

--- a/src/tools/getSettlementSummaries.ts
+++ b/src/tools/getSettlementSummaries.ts
@@ -68,7 +68,7 @@ export const config = {
 
 각 일자별로 정산 금액/건수, PG 수수료, 취소, 후보정 합산치와 상점·PG별 상세 내역을 제공합니다.
 날짜는 반드시 YYYY-MM-DD 형식으로 입력합니다.
-조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 3개월입니다.
+조회 기간 제약: from 은 최근 6개월 이내여야 하고, 한 번에 조회 가능한 구간은 최대 1개월입니다.
 store 아이디는 list_stores 도구로 먼저 조회할 수 있습니다.`,
   inputSchema: InputSchema.shape,
   outputSchema: OutputSchema.shape,
@@ -79,7 +79,9 @@ export function init(
   client: GraphQLClient,
 ): ToolCallback<typeof config.inputSchema> {
   return async ({ store, from, to, first, after }) => {
-    const dateRangeError = validateReconciliationDateRange(from, to);
+    const dateRangeError = validateReconciliationDateRange(from, to, {
+      months: 1,
+    });
     if (dateRangeError != null) {
       return toolErrorResult({
         type: "error",

--- a/src/tools/utils/dateRange.ts
+++ b/src/tools/utils/dateRange.ts
@@ -3,18 +3,34 @@
  *
  * - 조회 시작일(from)은 최근 LOOKBACK_MONTHS(6)개월 이내여야 합니다.
  *   (게이트웨이의 데이터 조회 한도와 동일한 제약을 클라이언트에서 선제 검증)
- * - 한 번에 조회 가능한 구간은 최대 MAX_RANGE_MONTHS(3)개월입니다.
+ * - 한 번에 조회 가능한 구간(maxRange)은 도구마다 다릅니다.
+ *   정산 요약/통계는 1개월, 건별 거래대사 내역은 2주.
  *
  * from/to 는 "YYYY-MM-DD" 형식의 문자열입니다.
- *
- * @returns 제약 위반 시 사용자용 에러 메시지, 유효하면 null
  */
 export const LOOKBACK_MONTHS = 6;
-export const MAX_RANGE_MONTHS = 3;
 
+/** 한 번에 조회 가능한 최대 구간. months 또는 days 중 하나로 지정합니다. */
+export type MaxRange = { months: number } | { days: number };
+
+function maxRangeLabel(maxRange: MaxRange): string {
+  if ("months" in maxRange) {
+    return `${maxRange.months}개월`;
+  }
+  if (maxRange.days % 7 === 0) {
+    return `${maxRange.days / 7}주`;
+  }
+  return `${maxRange.days}일`;
+}
+
+/**
+ * @param maxRange from 기준 허용되는 최대 조회 구간 (예: { months: 1 }, { days: 14 })
+ * @returns 제약 위반 시 사용자용 에러 메시지, 유효하면 null
+ */
 export function validateReconciliationDateRange(
   from: string,
   to: string,
+  maxRange: MaxRange,
 ): string | null {
   const fromDate = new Date(`${from}T00:00:00Z`);
   const toDate = new Date(`${to}T00:00:00Z`);
@@ -37,9 +53,13 @@ export function validateReconciliationDateRange(
   }
 
   const maxTo = new Date(fromDate);
-  maxTo.setUTCMonth(maxTo.getUTCMonth() + MAX_RANGE_MONTHS);
+  if ("months" in maxRange) {
+    maxTo.setUTCMonth(maxTo.getUTCMonth() + maxRange.months);
+  } else {
+    maxTo.setUTCDate(maxTo.getUTCDate() + maxRange.days);
+  }
   if (toDate > maxTo) {
-    return `조회 구간은 최대 ${MAX_RANGE_MONTHS}개월까지 가능합니다. from(${from}) 기준 ${maxTo
+    return `조회 구간은 최대 ${maxRangeLabel(maxRange)}까지 가능합니다. from(${from}) 기준 ${maxTo
       .toISOString()
       .slice(0, 10)} 이내로 to를 지정해주세요.`;
   }

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -82,18 +82,45 @@ describe("reconciliation tools", () => {
 });
 
 describe("validateReconciliationDateRange", () => {
-  it("최근 6개월 이내 & 3개월 이하 구간은 통과한다", () => {
+  it("정산(1개월): 최근 6개월 이내 & 1개월 이하 구간은 통과한다", () => {
     expect(
-      validateReconciliationDateRange(offsetDate(-1), offsetDate(0)),
+      validateReconciliationDateRange(offsetDate(-1), offsetDate(0), {
+        months: 1,
+      }),
     ).toBeNull();
-    // 2개월 구간(3개월 이하)은 허용
+    // 약 2주 구간도 1개월 이하이므로 허용
     expect(
-      validateReconciliationDateRange(offsetDate(-2), offsetDate(0)),
+      validateReconciliationDateRange(offsetDate(0, -14), offsetDate(0), {
+        months: 1,
+      }),
     ).toBeNull();
   });
 
+  it("정산(1개월): 구간이 1개월을 초과하면 거부한다", () => {
+    const err = validateReconciliationDateRange(offsetDate(-2), offsetDate(0), {
+      months: 1,
+    });
+    expect(err).toContain("1개월");
+  });
+
+  it("건별 대사(2주): 14일 이하 구간은 통과, 초과하면 거부한다", () => {
+    expect(
+      validateReconciliationDateRange(offsetDate(0, -14), offsetDate(0), {
+        days: 14,
+      }),
+    ).toBeNull();
+    const err = validateReconciliationDateRange(
+      offsetDate(0, -20),
+      offsetDate(0),
+      { days: 14 },
+    );
+    expect(err).toContain("2주");
+  });
+
   it("to 가 from 보다 빠르면 거부한다", () => {
-    const err = validateReconciliationDateRange(offsetDate(0), offsetDate(-1));
+    const err = validateReconciliationDateRange(offsetDate(0), offsetDate(-1), {
+      months: 1,
+    });
     expect(err).toContain("빠를 수 없습니다");
   });
 
@@ -101,19 +128,16 @@ describe("validateReconciliationDateRange", () => {
     const err = validateReconciliationDateRange(
       offsetDate(-7),
       offsetDate(-7, 5),
+      { months: 1 },
     );
     expect(err).toContain("6개월");
   });
 
-  it("구간이 3개월을 초과하면 거부한다", () => {
-    const err = validateReconciliationDateRange(offsetDate(-4), offsetDate(0));
-    // from 이 6개월 이내이므로 6개월 제약은 통과하고 3개월 제약에 걸려야 함
-    expect(err).toContain("3개월");
-  });
-
   it("잘못된 날짜 형식이면 거부한다", () => {
-    expect(validateReconciliationDateRange("2026-13-40", offsetDate(0))).toBe(
-      "날짜 형식이 올바르지 않습니다 (YYYY-MM-DD).",
-    );
+    expect(
+      validateReconciliationDateRange("2026-13-40", offsetDate(0), {
+        months: 1,
+      }),
+    ).toBe("날짜 형식이 올바르지 않습니다 (YYYY-MM-DD).");
   });
 });


### PR DESCRIPTION
## 개요

거래대사/정산 조회의 한 번당 조회 구간 제약을 축소합니다.

| 도구 | 기존 | 변경 |
|---|---|---|
| `getSettlementSummaries` (정산 요약) | 최대 3개월 | **최대 1개월** |
| `getSettlementStatistics` (정산 통계) | 최대 3개월 | **최대 1개월** |
| `getReconciliationsByFilter` (건별 대사 내역) | 최대 3개월 | **최대 2주** |

`from`(조회 시작일)의 최근 6개월 이내 제약은 그대로 유지됩니다.

## 구현

- `validateReconciliationDateRange(from, to, maxRange)` — 고정 3개월 상수 대신 도구별 `maxRange`(`{ months }` 또는 `{ days }`)를 인자로 받도록 변경.
- 에러 메시지도 `개월`/`주`/`일` 단위로 자동 표기.
- 각 도구 description의 기간 제약 안내 갱신.
- 단위 테스트 갱신 (1개월/2주 케이스 추가).

## 검증

`pnpm typecheck` / `pnpm lint` / `vitest` (12 tests) 통과.

## 릴리스

patch changeset 포함 (0.17.0 → 0.17.1). 머지 시 CD가 "Version Packages" PR 생성 → 머지하면 npm 배포.

> 참고: CD "Create GitHub Release" 단계는 알려진 이슈(태그 미push)로 실패하므로, 배포 후 태그 push + GitHub Release는 수동 보완이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)