### PR TITLE
fix: 거래대사 조회 에러 메시지 비어 나가는 문제 개선

### DIFF
--- a/.changeset/recon-error-message.md
+++ b/.changeset/recon-error-message.md
@@ -1,0 +1,5 @@
+---
+"@portone/mcp-server": patch
+---
+
+거래대사/정산 조회 시 GraphQL 오류(직렬화 실패 등) 응답의 에러 메시지가 비어 나가던 문제를 개선했습니다. 이제 GraphQL 에러의 message·extensions.code·path 를 함께 노출하고, message 가 비어 있으면 에러 코드로 대체해 항상 진단 가능한 정보를 반환합니다.

--- a/src/tools/request/getReconciliations.ts
+++ b/src/tools/request/getReconciliations.ts
@@ -3,6 +3,7 @@ import { type GraphQLClient, gql } from "graphql-request";
 import { match, P } from "ts-pattern";
 import z from "zod";
 import { nullableObject } from "../utils/nullableObject.ts";
+import { toRequestError } from "../utils/requestError.ts";
 import type { Result } from "../utils/result.ts";
 
 const ErrorResponse = z.object({
@@ -451,19 +452,6 @@ export async function getReconciliations({
         data,
       }));
   } catch (error) {
-    if (error instanceof Error) {
-      return {
-        type: "error",
-        data: error,
-      };
-    } else {
-      return {
-        type: "error",
-        data: {
-          message: `알 수 없는 오류가 발생했습니다.`,
-          cause: error,
-        },
-      };
-    }
+    return toRequestError(error);
   }
 }

--- a/src/tools/request/getSettlements.ts
+++ b/src/tools/request/getSettlements.ts
@@ -3,6 +3,7 @@ import { type GraphQLClient, gql } from "graphql-request";
 import { match, P } from "ts-pattern";
 import z from "zod";
 import { nullableObject } from "../utils/nullableObject.ts";
+import { toRequestError } from "../utils/requestError.ts";
 import type { Result } from "../utils/result.ts";
 import { ReconciliationPgProvider } from "./getReconciliations.ts";
 
@@ -338,14 +339,4 @@ export async function getSettlementStatistics({
   } catch (error) {
     return toRequestError(error);
   }
-}
-
-function toRequestError(error: unknown): Result<never> {
-  if (error instanceof Error) {
-    return { type: "error", data: error };
-  }
-  return {
-    type: "error",
-    data: { message: `알 수 없는 오류가 발생했습니다.`, cause: error },
-  };
 }

--- a/src/tools/utils/requestError.ts
+++ b/src/tools/utils/requestError.ts
@@ -1,0 +1,67 @@
+import type { Result } from "./result.ts";
+
+type GraphQLErrorEntry = {
+  message?: string;
+  path?: string;
+  code?: string;
+};
+
+/**
+ * 요청 중 발생한 예외를 사용자/디버깅에 유용한 형태의 에러 Result 로 변환합니다.
+ *
+ * graphql-request 는 응답에 GraphQL `errors` 가 있으면 ClientError 를 던집니다.
+ * 이 경우 게이트웨이가 내려준 message 가 빈 문자열일 수 있으므로, 각 에러의
+ * message / extensions.code / path 를 함께 추출하고, message 가 비어 있으면
+ * code 또는 기본 문구로 대체해 **message 가 절대 비지 않도록** 보장합니다.
+ */
+export function toRequestError(error: unknown): Result<never> {
+  const response = (error as { response?: unknown } | null)?.response as
+    | { errors?: unknown }
+    | undefined;
+  const rawErrors = response?.errors;
+
+  if (Array.isArray(rawErrors) && rawErrors.length > 0) {
+    const errors: GraphQLErrorEntry[] = rawErrors.map((entry) => {
+      const e = entry as {
+        message?: unknown;
+        path?: unknown;
+        extensions?: { code?: unknown };
+      };
+      const message =
+        typeof e.message === "string" && e.message.length > 0
+          ? e.message
+          : undefined;
+      const code =
+        e.extensions?.code != null ? String(e.extensions.code) : undefined;
+      const path = Array.isArray(e.path) ? e.path.join(".") : undefined;
+      return { message, code, path };
+    });
+
+    const primary = errors[0];
+    const message =
+      primary.message ??
+      (primary.code != null
+        ? `GraphQL 오류 (code: ${primary.code})`
+        : "GraphQL 오류가 발생했습니다. (서버가 상세 메시지를 반환하지 않음)");
+
+    return {
+      type: "error",
+      data: { message, type: "GraphQLError", errors },
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      type: "error",
+      data: {
+        message: error.message || error.name || "오류가 발생했습니다.",
+        type: error.name,
+      },
+    };
+  }
+
+  return {
+    type: "error",
+    data: { message: "알 수 없는 오류가 발생했습니다.", cause: String(error) },
+  };
+}

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -8,6 +8,7 @@ import {
   ReconciliationStatus,
 } from "../src/tools/request/getReconciliations.ts";
 import { validateReconciliationDateRange } from "../src/tools/utils/dateRange.ts";
+import { toRequestError } from "../src/tools/utils/requestError.ts";
 
 /** 오늘 기준 개월/일 오프셋의 YYYY-MM-DD 문자열 */
 function offsetDate(months: number, days = 0): string {
@@ -115,5 +116,59 @@ describe("validateReconciliationDateRange", () => {
     expect(validateReconciliationDateRange("2026-13-40", offsetDate(0))).toBe(
       "날짜 형식이 올바르지 않습니다 (YYYY-MM-DD).",
     );
+  });
+});
+
+describe("toRequestError", () => {
+  it("GraphQL 에러의 message 가 비어도 code 로 대체하고 path/code 를 함께 노출한다", () => {
+    const clientError = {
+      response: {
+        errors: [
+          {
+            message: "",
+            path: ["merchant", "reconciliation", "paymentReconciliations"],
+            extensions: { code: "INTERNAL" },
+          },
+        ],
+      },
+    };
+    const result = toRequestError(clientError);
+    expect(result.type).toBe("error");
+    const data = result.data as {
+      message: string;
+      type: string;
+      errors: { code?: string; path?: string }[];
+    };
+    expect(data.message).not.toBe("");
+    expect(data.message).toContain("INTERNAL");
+    expect(data.type).toBe("GraphQLError");
+    expect(data.errors[0].code).toBe("INTERNAL");
+    expect(data.errors[0].path).toBe(
+      "merchant.reconciliation.paymentReconciliations",
+    );
+  });
+
+  it("GraphQL 에러의 message 가 있으면 그대로 사용한다", () => {
+    const result = toRequestError({
+      response: { errors: [{ message: "직렬화 실패" }] },
+    });
+    expect((result.data as { message: string }).message).toBe("직렬화 실패");
+  });
+
+  it("일반 Error 는 message 를 사용하고, 비어 있으면 이름으로 대체한다", () => {
+    expect(
+      (toRequestError(new Error("boom")).data as { message: string }).message,
+    ).toBe("boom");
+    const named = new Error("");
+    named.name = "TypeError";
+    expect((toRequestError(named).data as { message: string }).message).toBe(
+      "TypeError",
+    );
+  });
+
+  it("알 수 없는 값도 비지 않은 message 를 반환한다", () => {
+    expect(
+      (toRequestError("weird").data as { message: string }).message,
+    ).not.toBe("");
   });
 });


### PR DESCRIPTION
## 배경

실제 검증 중 `merchant.reconciliation.paymentReconciliations` 쿼리(특정 정산일)에서 게이트웨이 오류가 발생했는데, MCP 도구가 반환한 에러 응답의 **`message` 필드가 빈 문자열**로 나가 원인 파악이 어려웠습니다.

원인: 게이트웨이가 GraphQL 실행 오류(예: 특정 레코드 직렬화 실패)를 내면 `graphql-request`가 `ClientError`를 던지는데, 이때 message가 비어 있을 수 있고 기존 코드는 원시 `Error` 객체를 그대로 전달했습니다.

## 변경

- 공용 `toRequestError()` 유틸 추가 (`src/tools/utils/requestError.ts`)
  - GraphQL 에러의 `message` / `extensions.code` / `path`를 함께 추출해 노출
  - `message`가 비어 있으면 **code로 대체**하여 항상 비지 않은 메시지 보장
- `getReconciliations.ts` / `getSettlements.ts`의 catch 처리를 이 유틸로 통일 (중복 제거)
- 단위 테스트 추가

이제 동일 오류 재발 시 `{ message, type: "GraphQLError", errors: [{ message, code, path }] }` 형태로 내려가 어느 필드/레코드에서 실패했는지 진단할 수 있습니다.

## 재현 조사 결과 (참고)

문제의 2026-05-06 정산분을 **전체 필드 + 전 상태 63,123건 전부 페이지네이션**해 재현을 시도했으나 **현재는 오류가 재현되지 않았습니다**(모두 정상 직렬화). 따라서 당시 실패는 일시적이거나 특정 store 부분집합/특정 레코드가 이후 재처리되어 해소됐을 가능성이 높습니다. 프로덕션 서버 로그의 예외 스택 및 어드민 콘솔 재현 여부는 백엔드팀 확인이 필요합니다(동일 게이트웨이 경로 `merchant.reconciliation.paymentReconciliations` 사용).

## 검증

`pnpm typecheck` / `pnpm lint` / `vitest` (15 tests) 통과.

patch changeset 포함 (다음 릴리스 시 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)