### PR TITLE
fix: 내부 dev 엔드포인트 URL 제거, env 오버라이드로 전환

### DIFF
--- a/.changeset/remove-dev-endpoint-urls.md
+++ b/.changeset/remove-dev-endpoint-urls.md
@@ -1,0 +1,5 @@
+---
+"@portone/mcp-server": minor
+---
+
+환경 전환 방식을 `PORTONE_ENV`(내부 환경 URL 하드코딩)에서 개별 엔드포인트 오버라이드로 변경합니다. `PORTONE_CONSOLE_URL` / `PORTONE_MERCHANT_SERVICE_URL` / `PORTONE_CHANNEL_SERVICE_URL` / `PORTONE_GRAPHQL_URL` 환경 변수로 각 서비스 엔드포인트를 개별 오버라이드할 수 있으며, 미설정 시 운영(prod) 환경 기본값을 사용합니다.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@
 >   별도의 프로세스에 해당 사용자의 토큰을 주입해, 토큰이 공유되지 않도록 하세요.
 > - `PORTONE_ACCESS_TOKEN` 이 없으면 기존과 동일하게 브라우저 로그인 플로우로 동작합니다.
 
-## 개발(dev) 환경으로 실행하기
+## 엔드포인트 오버라이드
 
-기본적으로 MCP 서버는 PortOne 운영(prod) 환경에 연결됩니다. `PORTONE_ENV`
-환경 변수로 개발(dev) 환경으로 전환할 수 있습니다.
+기본적으로 MCP 서버는 PortOne 운영(prod) 환경에 연결됩니다. 아래 환경 변수를
+설정하면 각 서비스 엔드포인트를 개별적으로 다른 환경(예: 내부 테스트 환경)으로
+오버라이드할 수 있습니다. 설정하지 않은 항목은 운영 환경 기본값을 사용합니다.
+
+- `PORTONE_CONSOLE_URL`: 콘솔 (OAuth 브라우저 로그인)
+- `PORTONE_MERCHANT_SERVICE_URL`: 머천트 서비스 (OAuth 토큰 교환·갱신)
+- `PORTONE_CHANNEL_SERVICE_URL`: 채널 서비스 (채널 조회·추가)
+- `PORTONE_GRAPHQL_URL`: GraphQL 게이트웨이 (스토어·결제·거래대사·정산)
 
 ```json
 "mcpServers": {
@@ -100,22 +106,18 @@
     "command": "npx",
     "args": ["-y", "@portone/mcp-server@latest"],
     "env": {
-      "PORTONE_ENV": "dev"
+      "PORTONE_CONSOLE_URL": "<대상 환경 콘솔 URL>",
+      "PORTONE_GRAPHQL_URL": "<대상 환경 GraphQL URL>"
     }
   }
 }
 ```
 
-- `PORTONE_ENV`: 연결할 환경(선택). `prod`(기본값) 또는 `dev`.
-  - `prod` 또는 미설정: 운영 환경(콘솔·머천트·채널 서비스·GraphQL 게이트웨이)에 연결합니다.
-  - `dev`: 개발 환경에 연결합니다.
-  - 그 외의 값이 들어오면 경고를 출력하고 운영 환경으로 동작합니다.
-
 > [!NOTE]
-> - `PORTONE_ENV` 는 콘솔 기능(스토어·채널·결제·거래대사·정산 등) 호출 대상 환경만
->   전환합니다. 문서/헬프센터 조회는 환경과 무관하게 동일하게 동작합니다.
-> - dev 환경에서는 dev 콘솔 계정으로 로그인해야 하며, `PORTONE_ACCESS_TOKEN` 을
->   함께 사용하는 경우 해당 dev 환경에서 발급한 토큰을 주입해야 합니다.
+> - 오버라이드는 콘솔 기능(스토어·채널·결제·거래대사·정산 등) 호출 대상만
+>   바꿉니다. 문서/헬프센터 조회는 환경과 무관하게 동일하게 동작합니다.
+> - 브라우저 로그인 대신 `PORTONE_ACCESS_TOKEN` 을 함께 사용하는 경우, 오버라이드한
+>   환경에서 발급한 토큰을 주입해야 합니다.
 
 ## 개발하기
 

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,70 +1,39 @@
 /**
  * PortOne 서비스 엔드포인트.
  *
- * `PORTONE_ENV` 환경 변수로 운영(prod) / 개발(dev) 환경을 전환합니다.
- * - 미설정 또는 `prod`: 운영 환경(기본값).
- * - `dev`: 개발 환경.
- * 알 수 없는 값이 들어오면 경고 후 운영 환경으로 동작합니다.
+ * 기본값은 운영(prod) 환경입니다. 아래 환경 변수를 설정하면 각 엔드포인트를
+ * 개별적으로 다른 환경(예: 내부 테스트 환경)으로 오버라이드할 수 있습니다.
+ * - `PORTONE_CONSOLE_URL`          : 콘솔 (OAuth authorize / 브라우저 로그인)
+ * - `PORTONE_MERCHANT_SERVICE_URL` : 머천트 서비스 (OAuth token 교환·갱신)
+ * - `PORTONE_CHANNEL_SERVICE_URL`  : 채널 서비스 (채널 조회·추가)
+ * - `PORTONE_GRAPHQL_URL`          : GraphQL 게이트웨이 (스토어·결제·거래대사·정산)
  *
- * 문서 사이트(DEVELOPERS_URL / HELP_CENTER_URL)는 환경과 무관하므로
- * 두 환경 모두 동일한 값을 사용합니다.
+ * 문서/헬프센터 URL은 환경과 무관하므로 오버라이드하지 않습니다.
  */
 
-type Environment = "prod" | "dev";
-
-interface Endpoints {
-  /** 개발자 문서 사이트 (환경 무관). */
-  DEVELOPERS_URL: string;
-  /** 콘솔. OAuth authorize(브라우저 로그인)에 사용. */
-  CONSOLE_URL: string;
-  /** 머천트 서비스. OAuth token 교환·갱신에 사용. */
-  MERCHANT_SERVICE_URL: string;
-  /** 채널 서비스. 채널 조회·추가에 사용. */
-  CHANNEL_SERVICE_URL: string;
-  /** GraphQL 게이트웨이. 스토어·결제·거래대사·정산 조회에 사용. */
-  GRAPHQL_URL: string;
-  /** 헬프센터 문서 사이트 (환경 무관). */
-  HELP_CENTER_URL: string;
+/**
+ * 환경 변수로 URL을 오버라이드하되, 값이 없거나 공백뿐이면 기본값을 사용한다.
+ */
+function urlFromEnv(name: string, fallback: string): string {
+  const value = process.env[name]?.trim();
+  return value ? value : fallback;
 }
 
-const PROD: Endpoints = {
-  DEVELOPERS_URL: "https://developers.portone.io",
-  CONSOLE_URL: "https://admin.portone.io",
-  MERCHANT_SERVICE_URL: "https://merchant-service.prod.iamport.co",
-  CHANNEL_SERVICE_URL: "https://channel-service.prod.iamport.co",
-  GRAPHQL_URL: "https://api.portone.io/graphql",
-  HELP_CENTER_URL: "https://help.portone.io",
-};
-
-const DEV: Endpoints = {
-  // 문서 사이트는 환경 무관하게 운영 값을 공용으로 사용합니다.
-  DEVELOPERS_URL: PROD.DEVELOPERS_URL,
-  HELP_CENTER_URL: PROD.HELP_CENTER_URL,
-  CONSOLE_URL: "https://port-console-dev.vercel.app",
-  MERCHANT_SERVICE_URL: "https://merchant-service.dev.iamport.co",
-  CHANNEL_SERVICE_URL: "https://channel-service.dev.iamport.co",
-  GRAPHQL_URL: "https://public-api-service.dev.iamport.co/graphql",
-};
-
-function resolveEnvironment(): Environment {
-  const raw = process.env.PORTONE_ENV?.trim().toLowerCase();
-  if (raw == null || raw === "" || raw === "prod") {
-    return "prod";
-  }
-  if (raw === "dev") {
-    return "dev";
-  }
-  console.error(
-    `Unknown PORTONE_ENV "${process.env.PORTONE_ENV}"; falling back to "prod". Valid values: "prod", "dev".`,
-  );
-  return "prod";
-}
-
-const endpoints: Endpoints = resolveEnvironment() === "dev" ? DEV : PROD;
-
-export const DEVELOPERS_URL = endpoints.DEVELOPERS_URL;
-export const CONSOLE_URL = endpoints.CONSOLE_URL;
-export const MERCHANT_SERVICE_URL = endpoints.MERCHANT_SERVICE_URL;
-export const CHANNEL_SERVICE_URL = endpoints.CHANNEL_SERVICE_URL;
-export const GRAPHQL_URL = endpoints.GRAPHQL_URL;
-export const HELP_CENTER_URL = endpoints.HELP_CENTER_URL;
+export const DEVELOPERS_URL = "https://developers.portone.io";
+export const HELP_CENTER_URL = "https://help.portone.io";
+export const CONSOLE_URL = urlFromEnv(
+  "PORTONE_CONSOLE_URL",
+  "https://admin.portone.io",
+);
+export const MERCHANT_SERVICE_URL = urlFromEnv(
+  "PORTONE_MERCHANT_SERVICE_URL",
+  "https://merchant-service.prod.iamport.co",
+);
+export const CHANNEL_SERVICE_URL = urlFromEnv(
+  "PORTONE_CHANNEL_SERVICE_URL",
+  "https://channel-service.prod.iamport.co",
+);
+export const GRAPHQL_URL = urlFromEnv(
+  "PORTONE_GRAPHQL_URL",
+  "https://api.portone.io/graphql",
+);

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,25 +1,33 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// url.ts 는 모듈 로드 시점에 PORTONE_ENV 를 읽으므로,
+const OVERRIDE_VARS = [
+  "PORTONE_CONSOLE_URL",
+  "PORTONE_MERCHANT_SERVICE_URL",
+  "PORTONE_CHANNEL_SERVICE_URL",
+  "PORTONE_GRAPHQL_URL",
+] as const;
+
+// url.ts 는 모듈 로드 시점에 환경 변수를 읽으므로,
 // env 를 설정한 뒤 모듈 캐시를 초기화하고 동적으로 import 한다.
-async function loadUrls(env?: string) {
+async function loadUrls(env: Record<string, string> = {}) {
   vi.resetModules();
-  if (env === undefined) {
-    delete process.env.PORTONE_ENV;
-  } else {
-    process.env.PORTONE_ENV = env;
+  for (const key of OVERRIDE_VARS) {
+    delete process.env[key];
   }
+  Object.assign(process.env, env);
   return import("../src/url.ts");
 }
 
-describe("환경별 엔드포인트(PORTONE_ENV)", () => {
+describe("엔드포인트 오버라이드", () => {
   afterEach(() => {
-    delete process.env.PORTONE_ENV;
+    for (const key of OVERRIDE_VARS) {
+      delete process.env[key];
+    }
     vi.restoreAllMocks();
   });
 
-  it("PORTONE_ENV 미설정 시 운영(prod) 엔드포인트를 사용한다", async () => {
-    const urls = await loadUrls(undefined);
+  it("오버라이드 env 가 없으면 운영(prod) 기본값을 사용한다", async () => {
+    const urls = await loadUrls();
     expect(urls.CONSOLE_URL).toBe("https://admin.portone.io");
     expect(urls.MERCHANT_SERVICE_URL).toBe(
       "https://merchant-service.prod.iamport.co",
@@ -30,45 +38,44 @@ describe("환경별 엔드포인트(PORTONE_ENV)", () => {
     expect(urls.GRAPHQL_URL).toBe("https://api.portone.io/graphql");
   });
 
-  it('PORTONE_ENV="prod" 이면 운영 엔드포인트를 사용한다', async () => {
-    const urls = await loadUrls("prod");
-    expect(urls.GRAPHQL_URL).toBe("https://api.portone.io/graphql");
+  it("각 env 변수로 해당 엔드포인트를 오버라이드한다", async () => {
+    const urls = await loadUrls({
+      PORTONE_CONSOLE_URL: "https://console.example.test",
+      PORTONE_MERCHANT_SERVICE_URL: "https://merchant.example.test",
+      PORTONE_CHANNEL_SERVICE_URL: "https://channel.example.test",
+      PORTONE_GRAPHQL_URL: "https://gateway.example.test/graphql",
+    });
+    expect(urls.CONSOLE_URL).toBe("https://console.example.test");
+    expect(urls.MERCHANT_SERVICE_URL).toBe("https://merchant.example.test");
+    expect(urls.CHANNEL_SERVICE_URL).toBe("https://channel.example.test");
+    expect(urls.GRAPHQL_URL).toBe("https://gateway.example.test/graphql");
   });
 
-  it('PORTONE_ENV="dev" 이면 개발 엔드포인트를 사용한다', async () => {
-    const urls = await loadUrls("dev");
-    expect(urls.CONSOLE_URL).toBe("https://port-console-dev.vercel.app");
-    expect(urls.MERCHANT_SERVICE_URL).toBe(
-      "https://merchant-service.dev.iamport.co",
-    );
-    expect(urls.CHANNEL_SERVICE_URL).toBe(
-      "https://channel-service.dev.iamport.co",
-    );
-    expect(urls.GRAPHQL_URL).toBe(
-      "https://public-api-service.dev.iamport.co/graphql",
-    );
+  it("일부만 오버라이드하면 나머지는 기본값을 유지한다", async () => {
+    const urls = await loadUrls({
+      PORTONE_GRAPHQL_URL: "https://gateway.example.test/graphql",
+    });
+    expect(urls.GRAPHQL_URL).toBe("https://gateway.example.test/graphql");
+    expect(urls.CONSOLE_URL).toBe("https://admin.portone.io");
   });
 
-  it("대소문자·공백을 무시하고 dev 를 인식한다", async () => {
-    const urls = await loadUrls("  DEV  ");
-    expect(urls.MERCHANT_SERVICE_URL).toBe(
-      "https://merchant-service.dev.iamport.co",
-    );
+  it("공백뿐인 값은 무시하고 기본값을 사용한다", async () => {
+    const urls = await loadUrls({ PORTONE_CONSOLE_URL: "   " });
+    expect(urls.CONSOLE_URL).toBe("https://admin.portone.io");
   });
 
-  it("문서 사이트 URL 은 환경과 무관하게 동일하다", async () => {
-    const prod = await loadUrls("prod");
-    const dev = await loadUrls("dev");
-    expect(dev.DEVELOPERS_URL).toBe(prod.DEVELOPERS_URL);
-    expect(dev.HELP_CENTER_URL).toBe(prod.HELP_CENTER_URL);
-    expect(dev.DEVELOPERS_URL).toBe("https://developers.portone.io");
-    expect(dev.HELP_CENTER_URL).toBe("https://help.portone.io");
+  it("값의 앞뒤 공백을 제거한다", async () => {
+    const urls = await loadUrls({
+      PORTONE_GRAPHQL_URL: "  https://gateway.example.test/graphql  ",
+    });
+    expect(urls.GRAPHQL_URL).toBe("https://gateway.example.test/graphql");
   });
 
-  it("알 수 없는 값이면 경고 후 운영 환경으로 폴백한다", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const urls = await loadUrls("staging");
-    expect(urls.GRAPHQL_URL).toBe("https://api.portone.io/graphql");
-    expect(errorSpy).toHaveBeenCalledOnce();
+  it("문서 사이트 URL 은 오버라이드 대상이 아니다", async () => {
+    const urls = await loadUrls({
+      PORTONE_CONSOLE_URL: "https://x.example.test",
+    });
+    expect(urls.DEVELOPERS_URL).toBe("https://developers.portone.io");
+    expect(urls.HELP_CENTER_URL).toBe("https://help.portone.io");
   });
 });


### PR DESCRIPTION
## 개요

public 저장소에 내부 개발 환경 호스트명이 하드코딩되어 노출되지 않도록, `PORTONE_ENV` 기반의 dev URL 하드코딩을 제거합니다. (#66 에서 도입된 방식 대체)

대신 각 서비스 엔드포인트를 환경 변수로 **개별 오버라이드**하도록 변경합니다. 소스에는 공개된 운영(prod) 기본값만 남습니다.

## 변경 사항

- `src/url.ts` — `PROD`/`DEV` 하드코딩 세트 + `PORTONE_ENV` 분기 제거. prod 기본값 + `urlFromEnv()` 개별 오버라이드 구조로 재작성.
  - `PORTONE_CONSOLE_URL`: 콘솔 (OAuth 브라우저 로그인)
  - `PORTONE_MERCHANT_SERVICE_URL`: 머천트 서비스 (OAuth 토큰 교환·갱신)
  - `PORTONE_CHANNEL_SERVICE_URL`: 채널 서비스 (채널 조회·추가)
  - `PORTONE_GRAPHQL_URL`: GraphQL 게이트웨이 (스토어·결제·거래대사·정산)
  - 미설정 시 운영(prod) 기본값 사용 → 기존 동작 유지
- `tests/url.test.ts` — 오버라이드 동작/기본값/공백 처리/문서 URL 불변 검증 (dev 호스트명 없이 `*.example.test` 사용)
- `README.md` — "엔드포인트 오버라이드" 섹션으로 교체
- changeset(minor) 추가

## 배경

`PORTONE_ENV` 방식은 내부 dev 호스트명을 소스에 하드코딩해야 했고, 이 저장소는 public 이므로 부적절합니다. 오버라이드 방식은 dev 주소를 MCP 클라이언트 config(비공개)에만 두면 됩니다.

## 검증

- `pnpm typecheck` / `pnpm lint` / `pnpm test`(27) 통과
- 트리 전체에서 dev 호스트명 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)