### PR TITLE
feat: 결제 내역 조회에 실패 사유·취소 사유 추가

### DIFF
--- a/.changeset/lucky-otters-report.md
+++ b/.changeset/lucky-otters-report.md
@@ -1,0 +1,9 @@
+---
+"@portone/mcp-server": minor
+---
+
+getPaymentsByFilter 에 결제 실패 사유·취소 사유 추가
+
+결제 내역 조회 결과에서 실패 사유(`failure.reason`, `failure.pgCode`, `failure.pgMessage`)와
+취소 내역별 취소 사유(`cancellation.reason`, 취소 금액·요청/완료 시각·요청 주체)를 조회할 수 있습니다.
+실패 사유는 실패한 결제건, 취소 사유는 전체/부분 취소된 결제건에만 존재합니다.

--- a/src/tools/getPaymentsByFilter.ts
+++ b/src/tools/getPaymentsByFilter.ts
@@ -71,6 +71,30 @@ const History = z
 type HistoryField = keyof typeof Amount.shape;
 const HistoryFields = Object.keys(History.shape);
 
+const Failure = z
+  .object({
+    reason: z.string().describe("결제 실패 사유"),
+    pgCode: z.string().describe("PG사 실패 코드"),
+    pgMessage: z.string().describe("PG사 실패 메시지"),
+  })
+  .partial();
+type FailureField = keyof typeof Failure.shape;
+const FailureFields = Object.keys(Failure.shape);
+
+const Cancellation = z
+  .object({
+    reason: z.string().describe("결제 취소 사유"),
+    amount: z.number().describe("취소 금액"),
+    requestAt: z.string().describe("취소 요청 시각"),
+    cancelAt: z.string().describe("취소 완료 시각"),
+    trigger: z
+      .string()
+      .describe("취소 요청 주체 (CONSOLE, API, PORTONE_ADMIN, CHARGEBACK)"),
+  })
+  .partial();
+type CancellationField = keyof typeof Cancellation.shape;
+const CancellationFields = Object.keys(Cancellation.shape);
+
 const Payment = z
   .object({
     amount: Amount.describe("금액 정보"),
@@ -88,6 +112,10 @@ const Payment = z
     requestAt: z.string().describe("결제 요청 시각"),
     paymentId: z.string().describe("고객사 거래번호 (V1에서는 merchant_uid)"),
     method: z.string().array().describe("사용된 결제수단 목록"),
+    failure: Failure.describe("결제 실패 정보. 실패한 결제건에만 존재함."),
+    cancellation: Cancellation.array().describe(
+      "결제 취소 내역. 전체 / 부분 취소된 결제건에만 존재함.",
+    ),
   })
   .partial();
 type PaymentField =
@@ -95,12 +123,16 @@ type PaymentField =
   | `amount.${AmountField}`
   | `channel.${ChannelField}`
   | `group.${ChannelGroupField}`
-  | `history.${HistoryField}`;
+  | `history.${HistoryField}`
+  | `failure.${FailureField}`
+  | `cancellation.${CancellationField}`;
 const PaymentFields = Object.keys(Payment.shape)
   .concat(AmountFields.map((key) => `amount.${key}`))
   .concat(ChannelFields.map((key) => `channel.${key}`))
   .concat(ChannelGroupFields.map((key) => `group.${key}`))
-  .concat(HistoryFields.map((key) => `history.${key}`)) as [
+  .concat(HistoryFields.map((key) => `history.${key}`))
+  .concat(FailureFields.map((key) => `failure.${key}`))
+  .concat(CancellationFields.map((key) => `cancellation.${key}`)) as [
   PaymentField,
   ...PaymentField[],
 ];
@@ -240,6 +272,8 @@ export function init(
         requestedAt,
         plainId,
         methodTypes,
+        failure,
+        cancellations,
       }): z.infer<typeof Payment> => {
         return {
           amount: {
@@ -294,6 +328,23 @@ export function init(
           requestAt: requestedAt ?? undefined,
           paymentId: plainId ?? undefined,
           method: methodTypes ?? undefined,
+          failure: failure
+            ? {
+                reason: failure.reason ?? undefined,
+                pgCode: failure.pgCode ?? undefined,
+                pgMessage: failure.pgMessage ?? undefined,
+              }
+            : undefined,
+          cancellation:
+            cancellations?.map(
+              ({ reason, totalAmount, requestedAt, cancelledAt, trigger }) => ({
+                reason: reason ?? undefined,
+                amount: totalAmount ?? undefined,
+                requestAt: requestedAt ?? undefined,
+                cancelAt: cancelledAt ?? undefined,
+                trigger: trigger ?? undefined,
+              }),
+            ) ?? undefined,
         };
       },
     );

--- a/src/tools/request/getPaymentsByFilter.ts
+++ b/src/tools/request/getPaymentsByFilter.ts
@@ -14,8 +14,26 @@ const PageResponse = z.object({
   totalCount: z.number(),
 });
 
-const PaymentResponse = z.object(
+const FailureResponse = z.object(
   nullableObject({
+    reason: z.string(),
+    pgCode: z.string(),
+    pgMessage: z.string(),
+  }),
+);
+
+const CancellationResponse = z.object(
+  nullableObject({
+    reason: z.string(),
+    totalAmount: z.number(),
+    requestedAt: z.string(),
+    cancelledAt: z.string(),
+    trigger: z.string(),
+  }),
+);
+
+const PaymentResponse = z.object({
+  ...nullableObject({
     amount: z.object(
       nullableObject({
         total: z.number(),
@@ -77,7 +95,10 @@ const PaymentResponse = z.object(
     methodTypes: z.array(z.string()),
     storeId: z.string(),
   }),
-);
+  // 실패·취소 사유는 결제 상태별 타입에만 존재하므로 응답에서 아예 누락될 수 있다.
+  failure: FailureResponse.nullish(),
+  cancellations: z.array(CancellationResponse).nullish(),
+});
 
 const PaymentsResponse = z
   .object({
@@ -202,10 +223,35 @@ fragment PaymentFragment on PaymentsPayload {
     requestedAt
     plainId
     methodTypes
+    ... on FailedPayment {
+      failure {
+        reason
+        pgCode
+        pgMessage
+      }
+    }
+    ... on CancelledPayment {
+      cancellations {
+        ...CancellationFragment
+      }
+    }
+    ... on PartialCancelledPayment {
+      cancellations {
+        ...CancellationFragment
+      }
+    }
   }
   page {
     totalCount
   }
+}
+
+fragment CancellationFragment on PaymentCancellation {
+  reason
+  totalAmount
+  requestedAt
+  cancelledAt
+  trigger
 }
 `);
 


### PR DESCRIPTION
## 개요

`getPaymentsByFilter` 로 결제 **실패 사유**와 **취소 사유**를 함께 조회할 수 있게 합니다.

- 실패 사유: `failure.reason` / `failure.pgCode` / `failure.pgMessage`
- 취소 사유: `cancellation[].reason` + 취소 금액(`amount`), 요청/완료 시각(`requestAt`/`cancelAt`), 요청 주체(`trigger`: CONSOLE, API, PORTONE_ADMIN, CHARGEBACK)

두 필드 모두 `fields` 파라미터로 선택할 수 있도록 `failure.*`, `cancellation.*` 경로를 노출했습니다.

## 구현 상세

`PaymentsPayload.items` 는 `Payment` 인터페이스이고, 실패/취소 사유는 상태별 구현 타입에만 존재합니다.

- `FailedPayment.failure: PaymentFailure!`
- `CancelledPayment.cancellations` / `PartialCancelledPayment.cancellations`

따라서 쿼리에서 해당 타입의 인라인 프래그먼트로 선택하고, 취소 내역은 `PaymentCancellation` 인터페이스 프래그먼트로 공통 처리했습니다. 다른 상태의 결제건에서는 응답에 키 자체가 없으므로 파싱 스키마에서는 `nullable` 이 아닌 `nullish` 로 처리했습니다.

## 검증

- 운영 GraphQL 스키마 인트로스펙션 결과로 쿼리 validate 통과
- `pnpm typecheck` / `pnpm lint` / `pnpm test` (27 passed) 통과
- 실제 API 응답으로 값을 받아보는 확인은 인증 토큰이 필요해 수행하지 않았습니다.

## 참고

`#70`(결제 내역 다건 조회 집계 도구)의 커서 조회 관련 작업은 이 브랜치에 포함되어 있지 않습니다. 해당 PR 은 그대로 열려 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)